### PR TITLE
Scrolling fixes

### DIFF
--- a/src/integrations/mokuro.ts
+++ b/src/integrations/mokuro.ts
@@ -71,6 +71,33 @@ try {
     for (const page of document.querySelectorAll('#pagesContainer > div')) {
         visible.observe(page);
     }
+
+    let isCursorInsidePopup = false;
+
+    window.addEventListener(
+        'wheel',
+        e => {
+            if (isCursorInsidePopup) {
+                e.stopPropagation();
+                e.preventDefault();
+            }
+        },
+        { capture: true },
+    );
+
+    document.addEventListener('mouseover', e => {
+        const popup = (e.target as HTMLElement)?.closest('#jpdb-popup');
+        if (popup) {
+            isCursorInsidePopup = true;
+        }
+    });
+
+    document.addEventListener('mouseout', e => {
+        const popup = (e.target as HTMLElement)?.closest('#jpdb-popup');
+        if (!popup) {
+            isCursorInsidePopup = false;
+        }
+    });
 } catch (error) {
     showError(error);
 }

--- a/src/integrations/ttu.ts
+++ b/src/integrations/ttu.ts
@@ -5,7 +5,7 @@ import { addedObserver, parseVisibleObserver } from './common.js';
 
 function shouldParse(node: Node): boolean {
     if (node instanceof HTMLElement) {
-        return !node.matches(`[data-ttu-spoiler-img]`);
+        return !node.matches('[data-ttu-spoiler-img]');
     } else {
         return true;
     }
@@ -23,6 +23,33 @@ try {
     added.observe(document.body, {
         subtree: true,
         childList: true,
+    });
+
+    let isCursorInsidePopup = false;
+
+    window.addEventListener(
+        'wheel',
+        e => {
+            if (isCursorInsidePopup) {
+                e.stopPropagation();
+                e.preventDefault();
+            }
+        },
+        { capture: true },
+    );
+
+    document.addEventListener('mouseover', e => {
+        const popup = (e.target as HTMLElement)?.closest('#jpdb-popup');
+        if (popup) {
+            isCursorInsidePopup = true;
+        }
+    });
+
+    document.addEventListener('mouseout', e => {
+        const popup = (e.target as HTMLElement)?.closest('#jpdb-popup');
+        if (!popup) {
+            isCursorInsidePopup = false;
+        }
     });
 } catch (error) {
     showError(error);


### PR DESCRIPTION
Prevents ttsu scrolling from triggering when scrolling inside a scrollable popup.

Prevents mokuro zooming when scrolling inside a scrollable popup. Resolves #52 (the first part at least).

There might be a better place to implement this since the code is pretty much the same for any website that handles its own scrolling.