### PR TITLE
Fix bug where popup appears and at the same time a (review) button is being clicked.

### DIFF
--- a/src/content/content.tsx
+++ b/src/content/content.tsx
@@ -119,6 +119,18 @@ export function onWordHoverStart({ target, x, y }: MouseEvent) {
     if (target === null) return;
     currentHover = [target as JpdbWord, x, y];
     if (popupKeyHeld || config.showPopupOnHover) {
+        // On mobile devices, the position of the popup is occasionally adjusted to ensure
+        // it remains on the screen. However, due to the interaction between the 'onmouseenter'
+        // event and the popup, there are instances where the popup appears and at the same
+        // time a (review) button is being clicked.
+        if (config.touchscreenSupport) {
+            Popup.get().disablePointer();
+
+            setTimeout(() => {
+                Popup.get().enablePointer();
+            }, 400);
+        }
+
         Popup.get().showForWord(target as JpdbWord, x, y);
     }
 }

--- a/src/content/popup.tsx
+++ b/src/content/popup.tsx
@@ -309,8 +309,8 @@ export class Popup {
 
     fadeIn() {
         // Necessary because in settings page, config is undefined
-        if (config) {
-            if (!config.disableFadeAnimation) this.#outerStyle.transition = 'opacity 60ms ease-in, visibility 60ms';
+        if (config && !config.disableFadeAnimation) {
+            this.#outerStyle.transition = 'opacity 60ms ease-in, visibility 60ms';
         }
         this.#outerStyle.opacity = '1';
         this.#outerStyle.visibility = 'visible';
@@ -318,8 +318,8 @@ export class Popup {
 
     fadeOut() {
         // Necessary because in settings page, config is undefined
-        if (config) {
-            if (!config.disableFadeAnimation) this.#outerStyle.transition = 'opacity 200ms ease-in, visibility 200ms';
+        if (config && !config.disableFadeAnimation) {
+            this.#outerStyle.transition = 'opacity 200ms ease-in, visibility 200ms';
         }
         this.#outerStyle.opacity = '0';
         this.#outerStyle.visibility = 'hidden';


### PR DESCRIPTION
On mobile devices, the position of the popup is occasionally adjusted to ensure it remains on the screen. However, due to the interaction between the 'onmouseenter' event and the popup, there are instances where the popup appears and at the same time a (review) button is being clicked. So I just disabled popup pointer events for a brief time. 