### PR TITLE
Compatibility with mokuro fork

### DIFF
--- a/src/integrations/mokuro.ts
+++ b/src/integrations/mokuro.ts
@@ -19,6 +19,7 @@ try {
                     const fragments: Fragment[] = [];
                     let offset = 0;
                     for (const p of box.children) {
+                        if (p.tagName !== 'P') continue;
                         const text = p.firstChild as Text;
                         text.data = text.data
                             .replaceAll('．．．', '…')


### PR DESCRIPTION
The mokuro fork https://github.com/ZXY101/mokuro adds an additional element where jpd-breader expects just paragraphs. This patch will make it so non-paragraph elements are ignored.

Fixes #60 