### PR TITLE
Fixing error with empty paragraphs in mokuro

### DIFF
--- a/src/integrations/mokuro.ts
+++ b/src/integrations/mokuro.ts
@@ -19,7 +19,8 @@ try {
                     const fragments: Fragment[] = [];
                     let offset = 0;
                     for (const p of box.children) {
-                        if (p.tagName !== 'P') continue;
+                        if (p.tagName !== 'P' || !p.firstChild)
+                            continue;
                         const text = p.firstChild as Text;
                         text.data = text.data
                             .replaceAll('．．．', '…')


### PR DESCRIPTION
When using the mokuro integration, sometimes mokuro will not find a character in a balloon, leaving an empty paragraph. When that happens, a fatal error is encountered and the whole integration breaks.