### PR TITLE
Add "affected" support

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,11 @@ Only color new words:
 .jpdb-word.not-in-deck { color: rgb(126, 173, 255); }
 ```
 
+Only color words which haven't been reviewed, mined, etc. during the current page load:
+```css
+.jpdb-word.affected { color: inherit !important; }
+```
+
 Show an underline rather than changing the text color:
 ```css
 .jpdb-word.new {

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -98,7 +98,7 @@ async function batchParses() {
             handle.resolve(tokens[i]);
         }
 
-        broadcast({ type: 'updateWordState', words: cards.map(card => [card.vid, card.sid, card.state]) });
+        broadcast({ type: 'updateWordState', words: cards.map(card => [card.vid, card.sid, false, card.state]) });
 
         return [null, timeout] as [null, number];
     } catch (error) {
@@ -152,8 +152,8 @@ function onPortDisconnect(port: browser.runtime.Port) {
     ports.delete(port);
 }
 
-async function broadcastNewWordState(vid: number, sid: number) {
-    broadcast({ type: 'updateWordState', words: [[vid, sid, await getCardState(vid, sid)]] });
+async function broadcastNewWordState(vid: number, sid: number, affected: boolean) {
+    broadcast({ type: 'updateWordState', words: [[vid, sid, affected, await getCardState(vid, sid)]] });
 }
 
 // Chrome can't send Error objects over background ports, so we have to serialize and deserialize them...
@@ -208,13 +208,13 @@ const messageHandlers: {
         }
 
         postResponse(port, request, null);
-        await broadcastNewWordState(request.vid, request.sid);
+        await broadcastNewWordState(request.vid, request.sid, true);
     },
 
     async review(request, port) {
         await review(request.vid, request.sid, request.rating);
         postResponse(port, request, null);
-        await broadcastNewWordState(request.vid, request.sid);
+        await broadcastNewWordState(request.vid, request.sid, true);
     },
 
     async mine(request, port) {
@@ -250,7 +250,7 @@ const messageHandlers: {
         }
 
         postResponse(port, request, null);
-        await broadcastNewWordState(request.vid, request.sid);
+        await broadcastNewWordState(request.vid, request.sid, true);
     },
 };
 

--- a/src/content/background_comms.tsx
+++ b/src/content/background_comms.tsx
@@ -138,11 +138,11 @@ port.onMessage.addListener((message: BackgroundToContentMessage, port) => {
 
         case 'updateWordState':
             {
-                for (const [vid, sid, state] of message.words) {
+                for (const [vid, sid, affected, state] of message.words) {
                     const idx = reverseIndex.get(`${vid}/${sid}`);
                     if (idx === undefined) continue;
 
-                    const className = `jpdb-word ${state.join(' ')}`;
+                    const className = `jpdb-word ${state.join(' ')}${affected ? ' affected' : ''}`;
                     if (idx.className === className) continue;
 
                     for (const element of idx.elements) {

--- a/src/content/word.css
+++ b/src/content/word.css
@@ -57,3 +57,16 @@
 :where(.jpdb-word.failed) {
     color: rgb(255, 0, 0);
 }
+
+:where(.jpdb-word.affected) {
+    animation: affected-animation 1s;
+}
+
+@keyframes affected-animation {
+    0% {
+        background-color: rgba(255, 255, 0, 0.5);
+    }
+    100% {
+        background-color: transparent;
+    }
+}

--- a/src/message_types.ts
+++ b/src/message_types.ts
@@ -107,5 +107,5 @@ export type UpdateConfigCommand = {
 
 export type UpdateWordStateCommand = {
     type: 'updateWordState';
-    words: [number, number, CardState][];
+    words: [number, number, boolean, CardState][];
 };


### PR DESCRIPTION
Whenever a word is mined or reviewed, add the "affected" class to it which lasts until the page is reloaded. This can be useful if a user wants to work through a piece of text word-by-word, reviewing or adding words as they go through, without having to remember where they left off. It also adds some visual feedback (currently flashes the background) for actions which makes it clearer when actions go through.